### PR TITLE
add context-management example: CRDT-backed multi-agent workflow context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,11 @@
 /examples/agent-registry/target
 /examples/agent-registry/spire-*
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info/
+dist/
+build/
+.venv/

--- a/examples/context-management/DESIGN.md
+++ b/examples/context-management/DESIGN.md
@@ -1,0 +1,188 @@
+# Context Management — Design Document
+
+## 1. What Problem Are We Solving?
+
+OpenEAGO workflows involve many agents running in parallel — a requirements analyst, an architect, a security reviewer, and more can all be reading and writing shared workflow state at the same time.  A naive approach (one shared dict, one database row, one LangGraph state object behind a single checkpointer) serialises every write through a central lock.  That bottleneck becomes the ceiling on how fast a workflow can move.
+
+Beyond throughput, enterprise deployments have a second hard requirement: every state change must be auditable.  Who wrote what, when, and in what order must be reconstructable after the fact — for SOC 2 reviews, incident postmortems, and blockchain anchoring of compliance evidence.
+
+This implementation addresses both concerns together.
+
+---
+
+## 2. What Is a CRDT?
+
+**CRDT** stands for **Conflict-free Replicated Data Type**.
+
+A CRDT is a data structure designed so that any number of independent copies (replicas) can accept writes concurrently, and those replicas can always be merged into a single consistent result — **without coordination, without locks, and without any replica ever having to "win" a conflict by discarding another's work**.
+
+The key mathematical property is **commutativity and idempotency of the merge operation**:
+
+```
+merge(A, B) == merge(B, A)          # order doesn't matter
+merge(A, merge(A, B)) == merge(A, B) # applying the same change twice is safe
+```
+
+Because merge is always safe to call, replicas can exchange state in any order, over unreliable networks, with arbitrary delays, and the result will still converge to the same value everywhere.
+
+### Two flavours relevant here
+
+| Type | Behaviour | Used for |
+|---|---|---|
+| **Grow-only set / append-only list** | Items can only be added, never removed. Any union of two replicas contains all items from both. | `journal` — audit events |
+| **Last-write-wins map (LWW-Map)** | For each key, the value with the most recent timestamp wins. New keys from either replica are always kept. | `playbook`, `agents`, `plan` |
+
+The `risk.composite_score` field uses neither of the above.  Instead it applies a **domain-specific merge policy** (max-score) layered on top of the structural CRDT merge, because the risk-conservative choice for a compliance system is always to surface the highest score observed across any replica.
+
+---
+
+## 3. Why CRDTs for OpenEAGO?
+
+### Alternative 1 — Shared mutable state (plain dict / database row)
+
+Every agent read and write goes through a single object.  Simple to reason about, but:
+
+- Requires a distributed lock or serialisable transaction for every mutation.
+- One slow or failed agent can block all others.
+- No built-in history; audit log must be added separately.
+
+### Alternative 2 — Hybrid graph + database
+
+A graph database stores the workflow DAG; a relational database stores state.  Richer query capability, but:
+
+- Two systems to keep in sync, two failure modes.
+- Merge logic becomes application-level SQL/Cypher, easy to get wrong under concurrency.
+- Still needs locking for concurrent writes to the same node.
+
+### Alternative 3 (chosen) — CRDT + event sourcing
+
+Each agent holds its own replica of the workflow context document.  Writes are local and instant.  When agents synchronise, replicas are merged deterministically.  An append-only change log is a by-product of every mutation.
+
+This fits OpenEAGO's needs precisely:
+
+| Requirement | How CRDTs satisfy it |
+|---|---|
+| Dozens of agents writing in parallel | Replicas diverge safely; no lock contention |
+| Eventual consistency acceptable | CRDT guarantee: all replicas converge after any merge |
+| Append-only audit log | The change history is intrinsic to the CRDT document |
+| Blockchain anchoring | `save()` produces a deterministic byte blob; hash it and anchor |
+| Resume after failure | Deserialise the last checkpoint; replay is automatic |
+| No LangGraph coupling | Standalone Python; export to LangGraph state is a one-liner |
+
+---
+
+## 4. How It Works — Layer by Layer
+
+```
+┌─────────────────────────────────────────────────────┐
+│  demo.py  /  agent code                             │  consumers
+├─────────────────────────────────────────────────────┤
+│  WorkflowContextStore   (workflow_context.py)       │  high-level API
+│  WorkflowContext / RiskContext / JournalEntry       │
+│                         (models.py)                 │  typed snapshots
+├─────────────────────────────────────────────────────┤
+│  crdt_backend.py                                    │  CRDT primitives
+│  Doc · create_doc · apply_change · merge_docs       │
+│  save_doc · load_doc · get_history                  │
+└─────────────────────────────────────────────────────┘
+```
+
+### 4.1 `crdt_backend.py` — CRDT primitives
+
+`Doc` is a plain Python object wrapping a dict (`_state`) and a list of change records (`_history`).  It exposes dict-like access (`doc["key"]`) so mutation lambdas can stay readable.
+
+Every mutation goes through `apply_change(doc, fn) -> Doc`:
+
+```python
+def apply_change(doc: Doc, fn: Callable[[Doc], None]) -> Doc:
+    new_state = copy.deepcopy(doc._state)   # snapshot
+    proxy = Doc(new_state, ...)
+    fn(proxy)                               # mutate the copy
+    new_history = doc._history + [change_record]
+    return Doc(new_state, new_history, ...)
+```
+
+The original doc is never mutated.  Each call returns a new Doc.  This is the same functional update pattern used by Automerge, Redux, and Elixir's immutable data structures.
+
+`merge_docs(local, remote) -> Doc` implements the structural CRDT merge:
+
+```
+For each field in the document:
+  list   → union  (items from remote not in local are appended;
+                   deduplication uses a JSON fingerprint of the whole item)
+  dict   → recurse (key-union; remote value wins for map conflicts)
+  scalar → keep local (domain policies applied by the caller afterwards)
+```
+
+The change histories are also merged: entries from both replicas are combined, deduplicated by `(actor, seq)`, and sorted by wall-clock time.
+
+### 4.2 `models.py` — Pydantic types
+
+`WorkflowContext` is a **read-only snapshot** — a Pydantic `BaseModel` built from the CRDT doc on demand.  Agents never mutate it; they call methods on `WorkflowContextStore` instead.
+
+`RiskContext` encodes the normative OpenEAGO risk taxonomy:
+
+```
+composite_score = financial×0.25 + operational×0.20
+                + compliance×0.30 + security×0.25
+```
+
+Thresholds map score to tier: `< 0.40` → low, `< 0.60` → medium, `< 0.80` → high, `≥ 0.80` → critical.  These constants come from `docs/overview/risk-management.md` and are not configurable at runtime.
+
+### 4.3 `workflow_context.py` — `WorkflowContextStore`
+
+The store is the only interface agents interact with.  Every write method wraps a single `apply_change` call:
+
+| Method | CRDT behaviour |
+|---|---|
+| `append_journal(entry)` | List append — naturally grows-only, merge is union |
+| `upsert_playbook(key, value)` | Map assignment — last-write-wins on merge |
+| `update_risk(dimensions, event)` | Computes score locally; max-score enforced at merge time |
+| `update_plan(patch)` | Shallow-merge patch into plan map |
+| `register_agent(id, metadata)` | Map upsert |
+
+`merge_with(other)` is where the two layers compose:
+
+```python
+def merge_with(self, other):
+    # Step 1: structural CRDT merge (list union + map key-union)
+    self._doc = merge_docs(self._doc, other._doc)
+
+    # Step 2: domain policy — risk is conservative, so take the max score
+    if other_score > local_score:
+        self._doc = apply_change(self._doc, lambda doc: set_max_score(...))
+```
+
+`snapshot()` converts the live CRDT doc into a validated, immutable `WorkflowContext` for safe consumption by read-only code or serialisation to JSON.
+
+`save()` / `load()` provide a JSON byte blob that can be:
+- Stored as a checkpoint between workflow phases.
+- Hashed and anchored to a blockchain for compliance evidence.
+- Sent over a message bus to synchronise replicas across machines.
+
+---
+
+## 5. Demonstrated Properties (from `demo.py`)
+
+The demo runs a three-agent SDLC scenario — requirements analyst, architect, security reviewer — all forked from the same initial state, working without coordination, then merged:
+
+| Assertion | What it proves |
+|---|---|
+| `len(journal) == 6` | No writes lost: all 6 events (2 per agent) survive the double merge |
+| `score == max(score_a, score_b, score_c)` | Max-score policy: the most conservative risk reading wins |
+| `tier == score_to_tier(max_score)` | Tier derives from score, not from whichever replica happened to be "local" |
+| `playbook.keys() == {"requirements", "design", "security"}` | Map union: all three agents' entries are present |
+| Roundtrip: `load(save()).snapshot() == snapshot()` | Serialisation is lossless |
+| `len(history) == 8` | Append-only change log accumulates across all agents and merges |
+
+---
+
+## 6. Extension Points
+
+**Swap in real Automerge.**  `crdt_backend.py` is intentionally isolated.  When the `automerge` Python bindings mature (the Rust library is production-grade; the Python wrapper was a stub as of March 2026), only `crdt_backend.py` changes — `workflow_context.py`, `models.py`, and all agent code stay the same.
+
+**LangGraph interop.**  `WorkflowContextStore.snapshot()` returns a Pydantic model.  A LangGraph custom checkpointer adapter needs only to call `store.save()` on `on_step_end` and `WorkflowContextStore.load(data)` on `on_step_start`.
+
+**Blockchain anchoring.**  `store.save()` returns a deterministic byte blob.  Hash it with SHA-256 and write the hash to an on-chain audit contract.  The full blob can be stored off-chain (IPFS, S3) with the hash as the pointer.
+
+**Multi-node distribution.**  Replicas can be exchanged over any transport (HTTP, message queue, gRPC).  The receiving node calls `store.merge_with(received_store)`.  No coordinator required.

--- a/examples/context-management/context_management/__init__.py
+++ b/examples/context-management/context_management/__init__.py
@@ -1,0 +1,12 @@
+"""OpenEAGO Context Management — CRDT-backed workflow context for concurrent multi-agent scenarios."""
+
+from .models import JournalEntry, RiskContext, RiskDimension, WorkflowContext
+from .workflow_context import WorkflowContextStore
+
+__all__ = [
+    "JournalEntry",
+    "RiskContext",
+    "RiskDimension",
+    "WorkflowContext",
+    "WorkflowContextStore",
+]

--- a/examples/context-management/context_management/crdt_backend.py
+++ b/examples/context-management/context_management/crdt_backend.py
@@ -1,0 +1,150 @@
+"""Pure-Python CRDT-inspired document backend.
+
+The PyPI `automerge` package (0.1.2) is a minimal Rust stub that lacks
+`change()`, `save()`, and a usable `merge()`.  This module implements the
+same interface using only the Python standard library so the demo runs
+without any native dependencies.
+
+Key CRDT properties preserved:
+  - Journal (list): union on merge — no entries are lost
+  - Maps (playbook, plan, agents): key-union with last-writer-wins
+  - Risk scalar fields: kept from local; max-score policy applied by
+    WorkflowContextStore.merge_with() after the structural merge
+  - History: append-only change log, deduped and sorted by wall-clock time
+  - Serialisation: JSON round-trip via save_doc / load_doc
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import time
+import uuid
+from typing import Any, Callable
+
+
+# ---------------------------------------------------------------------------
+# Doc — dict-like container with a change log
+# ---------------------------------------------------------------------------
+
+class Doc:
+    """Mutable document backed by a plain dict, with an append-only change log."""
+
+    def __init__(self, state: dict, history: list[dict], actor: str) -> None:
+        self._state = state
+        self._history = history
+        self._actor = actor
+
+    # dict-like read access so workflow_context can use doc["key"] syntax
+    def __getitem__(self, key: str) -> Any:
+        return self._state[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self._state[key] = value
+
+    def __contains__(self, key: str) -> bool:
+        return key in self._state
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self._state.get(key, default)
+
+
+# ---------------------------------------------------------------------------
+# Public API (mirrors the automerge module-level functions in the plan)
+# ---------------------------------------------------------------------------
+
+def create_doc(initial_data: dict) -> Doc:
+    """Create a new document initialised from *initial_data*."""
+    actor = str(uuid.uuid4())[:8]
+    state = copy.deepcopy(initial_data)
+    history = [{"actor": actor, "seq": 1, "time": time.time(), "message": "init"}]
+    return Doc(state, history, actor)
+
+
+def apply_change(doc: Doc, fn: Callable[[Doc], None]) -> Doc:
+    """Apply *fn* to a mutable copy of *doc* and return the updated Doc."""
+    new_state = copy.deepcopy(doc._state)
+    proxy = Doc(new_state, doc._history, doc._actor)
+    fn(proxy)
+
+    new_history = list(doc._history) + [{
+        "actor": doc._actor,
+        "seq": len(doc._history) + 1,
+        "time": time.time(),
+    }]
+    return Doc(new_state, new_history, doc._actor)
+
+
+def merge_docs(local: Doc, remote: Doc) -> Doc:
+    """Merge *remote* into *local* (CRDT semantics, returns a new Doc).
+
+    Merge rules:
+    - Lists  → union (deduplicated by JSON fingerprint)
+    - Maps   → key-union; remote value wins for conflicts
+    - Scalars → keep local value (callers apply domain-specific policies)
+    """
+    merged_state = copy.deepcopy(local._state)
+    _deep_merge(merged_state, remote._state)
+
+    # Merge histories: combine, dedup by (actor, seq), sort by time
+    seen: set[tuple] = set()
+    combined: list[dict] = []
+    for change in list(local._history) + list(remote._history):
+        key = (change.get("actor"), change.get("seq"))
+        if key not in seen:
+            seen.add(key)
+            combined.append(change)
+    combined.sort(key=lambda c: c.get("time", 0))
+
+    return Doc(merged_state, combined, local._actor)
+
+
+def save_doc(doc: Doc) -> bytes:
+    """Serialize *doc* to UTF-8 JSON bytes."""
+    payload = {"state": doc._state, "history": doc._history, "actor": doc._actor}
+    return json.dumps(payload, default=str).encode("utf-8")
+
+
+def load_doc(data: bytes) -> Doc:
+    """Deserialize a Doc from bytes produced by :func:`save_doc`."""
+    payload = json.loads(data.decode("utf-8"))
+    return Doc(payload["state"], payload["history"], payload["actor"])
+
+
+def get_history(doc: Doc) -> list[dict]:
+    """Return the append-only change log (audit / blockchain anchoring)."""
+    return list(doc._history)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _deep_merge(target: dict, source: dict) -> None:
+    """Recursively merge *source* into *target* in-place.
+
+    - Lists : union — items from source absent in target are appended.
+              Deduplication uses a JSON fingerprint so dict-valued items
+              (journal entries) are compared by content, not identity.
+    - Dicts : recurse.
+    - Scalars: keep target value (caller applies domain policy afterwards).
+    """
+    for key, src_val in source.items():
+        if key not in target:
+            target[key] = copy.deepcopy(src_val)
+            continue
+
+        tgt_val = target[key]
+
+        if isinstance(tgt_val, list) and isinstance(src_val, list):
+            existing_fps = {json.dumps(item, sort_keys=True, default=str) for item in tgt_val}
+            for item in src_val:
+                fp = json.dumps(item, sort_keys=True, default=str)
+                if fp not in existing_fps:
+                    tgt_val.append(copy.deepcopy(item))
+                    existing_fps.add(fp)
+
+        elif isinstance(tgt_val, dict) and isinstance(src_val, dict):
+            _deep_merge(tgt_val, src_val)
+
+        # scalar: keep target (callers handle domain-specific policies)

--- a/examples/context-management/context_management/models.py
+++ b/examples/context-management/context_management/models.py
@@ -1,0 +1,93 @@
+"""Pydantic v2 models for OpenEAGO workflow context.
+
+Aligned with the normative risk/compliance model defined in
+docs/overview/risk-management.md and the OpenEAGO Phase 5 proposal.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class JournalEntry(BaseModel):
+    """Append-only audit event recorded by an agent."""
+
+    timestamp: str = Field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+    agent_id: str
+    task_id: str
+    event_type: Literal["claimed", "started", "completed", "failed", "retry", "escalated"]
+    outcome: Optional[Dict[str, Any]] = None
+    risk_delta: Optional[Dict[str, Any]] = None
+
+
+class RiskDimension(BaseModel):
+    """Per-dimension risk scores (0.0–1.0).
+
+    Weights are normative constants from docs/overview/risk-management.md:
+      financial=0.25, operational=0.20, compliance=0.30, security=0.25
+    """
+
+    financial: float = 0.0    # weight 0.25
+    operational: float = 0.0  # weight 0.20
+    compliance: float = 0.0   # weight 0.30
+    security: float = 0.0     # weight 0.25
+
+
+class RiskContext(BaseModel):
+    """Aggregated risk state for the workflow."""
+
+    composite_score: float = 0.0
+    tier: Literal["low", "medium", "high", "critical"] = "low"
+    dimensions: RiskDimension = Field(default_factory=RiskDimension)
+    events: List[Dict[str, Any]] = Field(default_factory=list)
+
+    @staticmethod
+    def compute_composite(d: RiskDimension) -> float:
+        """Weighted composite risk score per normative spec."""
+        return (
+            d.financial * 0.25
+            + d.operational * 0.20
+            + d.compliance * 0.30
+            + d.security * 0.25
+        )
+
+    @staticmethod
+    def score_to_tier(score: float) -> str:
+        """Map composite score to normative risk tier.
+
+        Thresholds from docs/overview/risk-management.md:
+          < 0.40 → low
+          < 0.60 → medium
+          < 0.80 → high
+          >= 0.80 → critical
+        """
+        if score < 0.40:
+            return "low"
+        if score < 0.60:
+            return "medium"
+        if score < 0.80:
+            return "high"
+        return "critical"
+
+
+class WorkflowContext(BaseModel):
+    """Read-only Pydantic snapshot of a WorkflowContextStore.
+
+    Mirrors LangGraph state patterns (append-only journal, map-based playbook)
+    but is produced from a CRDT-backed document — never mutated directly.
+    """
+
+    workflow_id: str
+    goal: str
+    objective_details: Dict[str, Any] = Field(default_factory=dict)
+    journal: List[JournalEntry] = Field(default_factory=list)
+    playbook: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
+    risk: RiskContext = Field(default_factory=RiskContext)
+    plan: Dict[str, Any] = Field(default_factory=dict)
+    agents: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
+    metadata: Dict[str, Any] = Field(default_factory=dict)

--- a/examples/context-management/context_management/workflow_context.py
+++ b/examples/context-management/context_management/workflow_context.py
@@ -1,0 +1,190 @@
+"""High-level WorkflowContextStore — the main interface agents use.
+
+Each mutating operation is a single Automerge change transaction, making
+all updates CRDT-safe.  The max-score merge policy for risk is enforced
+in :meth:`merge_with` after the automatic CRDT merge.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Dict, List, Optional
+
+from .crdt_backend import (
+    apply_change,
+    create_doc,
+    get_history,
+    load_doc,
+    merge_docs,
+    save_doc,
+)
+from .models import JournalEntry, RiskContext, RiskDimension, WorkflowContext
+
+
+class WorkflowContextStore:
+    """CRDT-backed, high-level context store for one workflow."""
+
+    def __init__(
+        self,
+        workflow_id: str,
+        goal: str,
+        **objective_details: Any,
+    ) -> None:
+        initial: dict = {
+            "workflow_id": workflow_id,
+            "goal": goal,
+            "objective_details": dict(objective_details),
+            "journal": [],
+            "playbook": {},
+            "risk": {
+                "composite_score": 0.0,
+                "tier": "low",
+                "dimensions": {
+                    "financial": 0.0,
+                    "operational": 0.0,
+                    "compliance": 0.0,
+                    "security": 0.0,
+                },
+                "events": [],
+            },
+            "plan": {},
+            "agents": {},
+            "metadata": {},
+        }
+        self._doc = create_doc(initial)
+
+    # ------------------------------------------------------------------
+    # Write operations
+    # ------------------------------------------------------------------
+
+    def append_journal(self, entry: JournalEntry) -> None:
+        """Append an audit event to the journal (naturally CRDT-safe)."""
+        entry_dict = entry.model_dump()
+
+        def _change(doc: Any) -> None:
+            doc["journal"].append(entry_dict)
+
+        self._doc = apply_change(self._doc, _change)
+
+    def upsert_playbook(self, key: str, value: Dict[str, Any]) -> None:
+        """Upsert a playbook entry (last-write-wins per Automerge map semantics)."""
+        def _change(doc: Any) -> None:
+            doc["playbook"][key] = value
+
+        self._doc = apply_change(self._doc, _change)
+
+    def update_risk(
+        self,
+        dimensions: RiskDimension,
+        event: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Recompute composite score and tier, then persist.
+
+        The max-score merge policy is enforced at merge time in
+        :meth:`merge_with`; this method simply stores the local computation.
+        """
+        score = RiskContext.compute_composite(dimensions)
+        tier = RiskContext.score_to_tier(score)
+        dims_dict = dimensions.model_dump()
+
+        def _change(doc: Any) -> None:
+            doc["risk"]["composite_score"] = score
+            doc["risk"]["tier"] = tier
+            doc["risk"]["dimensions"] = dims_dict
+            if event is not None:
+                doc["risk"]["events"].append(event)
+
+        self._doc = apply_change(self._doc, _change)
+
+    def update_plan(self, patch: Dict[str, Any]) -> None:
+        """Shallow-merge *patch* into the plan map."""
+        def _change(doc: Any) -> None:
+            for k, v in patch.items():
+                doc["plan"][k] = v
+
+        self._doc = apply_change(self._doc, _change)
+
+    def register_agent(self, agent_id: str, metadata: Dict[str, Any]) -> None:
+        """Upsert agent registration metadata."""
+        def _change(doc: Any) -> None:
+            doc["agents"][agent_id] = metadata
+
+        self._doc = apply_change(self._doc, _change)
+
+    # ------------------------------------------------------------------
+    # CRDT merge
+    # ------------------------------------------------------------------
+
+    def merge_with(self, other: "WorkflowContextStore") -> None:
+        """Merge *other* into this store.
+
+        1. CRDT-merge the Automerge docs (journal/playbook handled automatically).
+        2. Apply max-score policy for risk.composite_score post-merge.
+        """
+        self._doc = merge_docs(self._doc, other._doc)
+
+        # Max-score policy: keep the highest composite_score observed across
+        # all merged replicas and re-derive the tier from it.
+        local_score: float = self._doc["risk"]["composite_score"]
+        other_score: float = other._doc["risk"]["composite_score"]
+
+        if other_score > local_score:
+            winning_score = other_score
+            winning_dims = dict(other._doc["risk"]["dimensions"])
+
+            def _fix_risk(doc: Any) -> None:
+                doc["risk"]["composite_score"] = winning_score
+                doc["risk"]["tier"] = RiskContext.score_to_tier(winning_score)
+                doc["risk"]["dimensions"] = winning_dims
+
+            self._doc = apply_change(self._doc, _fix_risk)
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+
+    def save(self) -> bytes:
+        """Serialize the Automerge document to bytes."""
+        return save_doc(self._doc)
+
+    @classmethod
+    def load(cls, data: bytes) -> "WorkflowContextStore":
+        """Deserialize a store from bytes produced by :meth:`save`."""
+        instance = object.__new__(cls)
+        instance._doc = load_doc(data)
+        return instance
+
+    # ------------------------------------------------------------------
+    # Read
+    # ------------------------------------------------------------------
+
+    def snapshot(self) -> WorkflowContext:
+        """Return a Pydantic snapshot of the current document state."""
+        doc = self._doc
+
+        risk_raw = doc["risk"]
+        dims = RiskDimension(**dict(risk_raw["dimensions"]))
+        risk = RiskContext(
+            composite_score=float(risk_raw["composite_score"]),
+            tier=risk_raw["tier"],  # type: ignore[arg-type]
+            dimensions=dims,
+            events=list(risk_raw["events"]),
+        )
+
+        journal = [JournalEntry(**dict(e)) for e in doc["journal"]]
+
+        return WorkflowContext(
+            workflow_id=doc["workflow_id"],
+            goal=doc["goal"],
+            objective_details=dict(doc.get("objective_details", {})),
+            journal=journal,
+            playbook={k: dict(v) for k, v in doc.get("playbook", {}).items()},
+            risk=risk,
+            plan=dict(doc.get("plan", {})),
+            agents={k: dict(v) for k, v in doc.get("agents", {}).items()},
+            metadata=dict(doc.get("metadata", {})),
+        )
+
+    def history(self) -> list[dict]:
+        """Return Automerge change history for audit / blockchain anchoring."""
+        return get_history(self._doc)

--- a/examples/context-management/demo.py
+++ b/examples/context-management/demo.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Demo: concurrent multi-agent context updates with CRDT merge.
+
+Scenario: SDLC workflow — 3 agents claim tasks and update context concurrently.
+
+Run:
+    cd examples/context-management
+    pip install -e .
+    python demo.py
+"""
+
+from context_management import JournalEntry, RiskContext, RiskDimension, WorkflowContextStore
+
+# ---------------------------------------------------------------------------
+# 1. Create shared workflow context
+# ---------------------------------------------------------------------------
+print("=" * 60)
+print("OpenEAGO Context Management — Concurrent Agent Demo")
+print("=" * 60)
+
+shared = WorkflowContextStore(
+    workflow_id="wf-sdlc-001",
+    goal="Automated SDLC: requirements -> design -> implementation -> review",
+    sprint="sprint-42",
+    compliance_tier="SOC2",
+)
+
+shared.update_plan({
+    "phases": ["requirements", "design", "implementation", "review"],
+    "sla_hours": 48,
+})
+
+# ---------------------------------------------------------------------------
+# 2. Fork into 3 agent stores (simulating diverged replicas)
+# ---------------------------------------------------------------------------
+# In production each agent would receive save() bytes over the wire;
+# here we simulate by copying the serialised bytes.
+agent_a = WorkflowContextStore.load(shared.save())
+agent_b = WorkflowContextStore.load(shared.save())
+agent_c = WorkflowContextStore.load(shared.save())
+
+# ---------------------------------------------------------------------------
+# 3. Each agent performs work concurrently (no coordination)
+# ---------------------------------------------------------------------------
+
+# --- Agent A: Requirements analyst ---
+agent_a.register_agent("agent-a", {"role": "requirements_analyst", "version": "1.0"})
+
+agent_a.append_journal(JournalEntry(
+    agent_id="agent-a", task_id="task-req-001",
+    event_type="claimed",
+))
+agent_a.append_journal(JournalEntry(
+    agent_id="agent-a", task_id="task-req-001",
+    event_type="started",
+    outcome={"approach": "stakeholder-interview"},
+))
+agent_a.upsert_playbook("requirements", {
+    "method": "event-storming",
+    "artefacts": ["bounded-contexts.md", "ubiquitous-language.md"],
+})
+agent_a.update_risk(
+    RiskDimension(financial=0.3, operational=0.4, compliance=0.5, security=0.2),
+    event={"source": "agent-a", "note": "Compliance gap identified in data retention"},
+)
+score_a = agent_a.snapshot().risk.composite_score
+print(f"\n[AGENT-A] Risk score: {score_a:.4f}  tier: {agent_a.snapshot().risk.tier}")
+
+# --- Agent B: Architect ---
+agent_b.register_agent("agent-b", {"role": "architect", "version": "1.0"})
+
+agent_b.append_journal(JournalEntry(
+    agent_id="agent-b", task_id="task-design-001",
+    event_type="claimed",
+))
+agent_b.append_journal(JournalEntry(
+    agent_id="agent-b", task_id="task-design-001",
+    event_type="started",
+    outcome={"approach": "C4-model"},
+))
+agent_b.upsert_playbook("design", {
+    "pattern": "hexagonal-architecture",
+    "artefacts": ["c4-context.png", "c4-container.png"],
+})
+agent_b.update_risk(
+    RiskDimension(financial=0.6, operational=0.7, compliance=0.8, security=0.6),
+    event={"source": "agent-b", "note": "Third-party dependency risk elevated"},
+)
+score_b = agent_b.snapshot().risk.composite_score
+print(f"[AGENT-B] Risk score: {score_b:.4f}  tier: {agent_b.snapshot().risk.tier}")
+
+# --- Agent C: Security reviewer ---
+agent_c.register_agent("agent-c", {"role": "security_reviewer", "version": "1.0"})
+
+agent_c.append_journal(JournalEntry(
+    agent_id="agent-c", task_id="task-sec-001",
+    event_type="claimed",
+))
+agent_c.append_journal(JournalEntry(
+    agent_id="agent-c", task_id="task-sec-001",
+    event_type="started",
+    outcome={"approach": "STRIDE-threat-model"},
+))
+agent_c.upsert_playbook("security", {
+    "framework": "STRIDE",
+    "artefacts": ["threat-model.md", "mitigations.md"],
+})
+agent_c.update_risk(
+    RiskDimension(financial=0.2, operational=0.3, compliance=0.6, security=0.6),
+    event={"source": "agent-c", "note": "Auth boundary requires review"},
+)
+score_c = agent_c.snapshot().risk.composite_score
+print(f"[AGENT-C] Risk score: {score_c:.4f}  tier: {agent_c.snapshot().risk.tier}")
+
+# ---------------------------------------------------------------------------
+# 4. Merge: agent_b → agent_a, then agent_c → merged
+# ---------------------------------------------------------------------------
+print("\n--- Merging replicas ---")
+agent_a.merge_with(agent_b)
+agent_a.merge_with(agent_c)
+merged = agent_a  # rename for clarity
+
+snap = merged.snapshot()
+
+# ---------------------------------------------------------------------------
+# 5. Verify journal: all 6 entries present
+# ---------------------------------------------------------------------------
+print(f"\n[MERGE] Journal entries: {len(snap.journal)}")
+assert len(snap.journal) == 6, f"Expected 6 journal entries, got {len(snap.journal)}"
+agents_in_journal = {e.agent_id for e in snap.journal}
+assert agents_in_journal == {"agent-a", "agent-b", "agent-c"}, (
+    f"Expected entries from all 3 agents, got: {agents_in_journal}"
+)
+for entry in snap.journal:
+    print(f"  [{entry.agent_id}] {entry.task_id} -> {entry.event_type}")
+
+# ---------------------------------------------------------------------------
+# 6. Verify risk: max-score policy
+# ---------------------------------------------------------------------------
+expected_max = max(score_a, score_b, score_c)
+print(f"\n[MERGE] Risk score: {snap.risk.composite_score:.4f}  tier: {snap.risk.tier}")
+print(f"        max(score_a, score_b, score_c) = {expected_max:.4f}")
+
+assert abs(snap.risk.composite_score - expected_max) < 1e-9, (
+    f"Max-score policy violated: {snap.risk.composite_score} != {expected_max}"
+)
+expected_tier = RiskContext.score_to_tier(expected_max)
+assert snap.risk.tier == expected_tier, (
+    f"Tier mismatch: got '{snap.risk.tier}', expected '{expected_tier}' for score {expected_max:.4f}"
+)
+
+# ---------------------------------------------------------------------------
+# 7. Verify playbook entries from all agents
+# ---------------------------------------------------------------------------
+print(f"\n[MERGE] Playbook keys: {sorted(snap.playbook.keys())}")
+assert set(snap.playbook.keys()) == {"requirements", "design", "security"}, (
+    f"Playbook missing entries: {snap.playbook.keys()}"
+)
+
+# ---------------------------------------------------------------------------
+# 8. Save / load roundtrip
+# ---------------------------------------------------------------------------
+blob = merged.save()
+restored = WorkflowContextStore.load(blob)
+snap2 = restored.snapshot()
+
+roundtrip_ok = (
+    snap2.workflow_id == snap.workflow_id
+    and len(snap2.journal) == len(snap.journal)
+    and abs(snap2.risk.composite_score - snap.risk.composite_score) < 1e-9
+    and snap2.risk.tier == snap.risk.tier
+    and set(snap2.playbook.keys()) == set(snap.playbook.keys())
+)
+print(f"\n[ROUNDTRIP] Snapshot matches after save/load: {roundtrip_ok}")
+assert roundtrip_ok, "Roundtrip produced a different snapshot!"
+
+# ---------------------------------------------------------------------------
+# 9. Audit history
+# ---------------------------------------------------------------------------
+history = merged.history()
+print(f"[HISTORY] Automerge change count: {len(history)}")
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+print("\n" + "=" * 60)
+print("All assertions passed.")
+print(f"  Workflow : {snap.workflow_id}")
+print(f"  Goal     : {snap.goal}")
+print(f"  Journal  : {len(snap.journal)} entries across {len(agents_in_journal)} agents")
+print(f"  Risk     : score={snap.risk.composite_score:.4f}  tier={snap.risk.tier}")
+print(f"  Playbook : {sorted(snap.playbook.keys())}")
+print(f"  Agents   : {sorted(snap.agents.keys())}")
+print(f"  Blob     : {len(blob)} bytes")
+print(f"  History  : {len(history)} Automerge changes")
+print("=" * 60)

--- a/examples/context-management/proposal.md
+++ b/examples/context-management/proposal.md
@@ -1,0 +1,26 @@
+### Full Thread Summary (decisions + rationale)
+
+**Core topic**: Context management for complex agentic workflows in OpenEAGO — overall goal, workflow graph (if present), agent/task ownership, execution status (who/what/when/outcome), in-progress/pending items, problems, risks, plus a continuously evolving GenAI “playbook/knowledge” layer.
+
+**Architectural foundation**
+- OpenEAGO already defines a hierarchical, propagating Context Capability (not a full autonomous agent) across six phases.  
+  *Reason*: Preserves enterprise auditability, compliance (blockchain anchoring, 7-year retention), and resilience (circuit breakers, SLA state machine) without reinventing the wheel.
+
+**Implementation strategy chosen**
+- **#3: CRDT + event sourcing / temporal versioning** (over #1 pure payload or #2 hybrid graph+DB).  
+  *Reason*: SDLC-style flows demand high concurrency (parallel variant generation/testing/ranking). CRDTs enable lock-free optimistic updates from dozens of agents; eventual consistency + append-only log gives perfect audit/resumption.
+
+**CRDT library & language**
+- **Automerge** (Python bindings — confirmed live & maturing as of March 2026) + **Python**.  
+  *Reason*: JSON-native document model matches OpenEAGO schemas perfectly; excellent Python ecosystem fit for AI agents; built-in immutable history for checkpoints/anchoring. Python wins for rapid prototyping + LLM/tool integration.
+
+**Relationship to LangGraph/LangChain**
+- Researched ecosystem → **standalone** (no hard dependency) but **partial data-model alignment**.  
+  *Reason*: Standalone frees us from LangGraph’s centralized checkpointer bottlenecks in high-concurrency scenarios, while Pydantic `WorkflowContext` (journal as append-only, playbook as map, risk object, etc.) mirrors LangGraph TypedDict/BaseModel patterns for familiarity and future interop (easy export/import or custom checkpointer adapter).
+
+**Data constructs & prototype**
+- Pydantic `WorkflowContext` facade + Automerge backing with high-level `change()` proxy. Journal = append-only, playbook = map upserts, risk = max-score merge policy.  
+  *Reason*: Gives clean validation + IDE support while keeping concurrency power. The runnable skeleton above is the direct result.
+
+**Overall decisions summary**  
+We deliberately stayed close to OpenEAGO’s normative hierarchy and risk/compliance model, chose the concurrency-first CRDT path for SDLC speed, picked Python + Automerge for practicality, and aligned just enough with LangGraph idioms for ergonomics — without coupling the implementation. This gives us a solid, extensible research foundation.

--- a/examples/context-management/pyproject.toml
+++ b/examples/context-management/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "openEAGO-context-management"
+version = "0.1.0"
+description = "Context & State Management example for OpenEAGO Phase 5 — CRDT + event sourcing via Automerge"
+requires-python = ">=3.11"
+dependencies = [
+    "pydantic>=2.0",
+]
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["context_management*"]


### PR DESCRIPTION
Implements OpenEAGO Phase 5 (Context & State Management) as a runnable Python example using a pure-Python CRDT backend (list-union + LWW-map merge, max-score risk policy, append-only audit log, JSON save/load).

- context_management/models.py      — Pydantic v2 models aligned with
                                      the normative risk taxonomy
- context_management/crdt_backend.py — isolated CRDT primitives (Doc,
                                      apply_change, merge_docs, save/load)
- context_management/workflow_context.py — WorkflowContextStore agent API
- demo.py                           — 3-agent concurrent scenario with
                                      assertions on journal union, max-score
                                      risk, and save/load roundtrip
- DESIGN.md                         — design document covering what CRDTs
                                      are, why they were chosen, and how
                                      each layer works
- .gitignore                        — add Python __pycache__ / build rules

---
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file.
- [x] My commit messages are signed off with the `Signed-off-by` statement (use `--signoff` in the commit).

By submitting this pull request, I certify that I have read and agree to the terms of the [Developer Certificate of Origin](https://developercertificate.org/).
