### PR TITLE
add provenance-manifest example: signed audit-grade inference records

### DIFF
--- a/examples/provenance_manifest/DESIGN.md
+++ b/examples/provenance_manifest/DESIGN.md
@@ -1,0 +1,206 @@
+# Provenance Manifest — Architecture & Design Rationale
+
+## Overview
+
+The Provenance Manifest extends OpenEAGO's tracing layer (section 4.4) with a
+**signed, structured record** that cryptographically anchors every component in
+an AI agent invocation chain.  The goal is to produce self-verifying,
+audit-grade inference records suitable for regulated enterprise deployments
+(EU AI Act, DORA, financial compliance).
+
+---
+
+## Module Layout
+
+```
+provenance_manifest/
+├── models.py      — Pydantic v2 data models (JSON schema)
+├── collector.py   — Artifact collection helpers (hash-and-assemble)
+├── signer.py      — ECDSA P-256 sign + verify
+└── verifier.py    — Full manifest verification with structured results
+```
+
+---
+
+## Manifest JSON Model
+
+A fully-populated manifest (all source fields present) looks like this:
+
+```json
+{
+  "invocation_id": "inv-2024-03-22-financial-7b-001",
+  "trace_root": "trace-root-sha256-fedcba9876543210",
+  "created_at": "2024-03-22T14:05:00.123456+00:00",
+  "sources": {
+    "model_runtime": {
+      "locator": "ghcr.io/finos-labs/open-eago-agent@sha256:abc123def456",
+      "sbom": {
+        "format": "cyclonedx-json",
+        "hash": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      }
+    },
+    "model_weights": {
+      "locator": "hf://finos-labs/open-eago-financial-7b",
+      "commit": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+      "hash": "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+      "signature": {
+        "type": "cosign",
+        "bundle_url": "https://rekor.sigstore.dev/api/v1/log/entries/abc123"
+      }
+    },
+    "rag": {
+      "index_snapshot": {
+        "locator": "s3://finos-labs-vectors/financial-compliance-v3/snapshot-2024-03-01",
+        "hash": "sha256:b94f6f125c79e3a5ffaa826f584c10d52ada669e6762051b826b55776d05a8d7"
+      },
+      "chunks": [
+        {
+          "source_doc_id": "doc-regulatory-guidelines-2024",
+          "chunk_hash": "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+          "retrieval_score": 0.92
+        },
+        {
+          "source_doc_id": "doc-dora-technical-standards",
+          "chunk_hash": "sha256:82e35a63ceba37e9646434c5dd412ea577147f1e4a41ccde1614253187e3dbbc",
+          "retrieval_score": 0.87
+        }
+      ]
+    },
+    "training_data": {
+      "locator": "s3://finos-labs-datasets/financial-instruct-v2.tar.gz",
+      "hash": "sha256:4e07408562bedb8b60ce05c1decf3ad7b3d191b4b7f705e37cd40e8abe8b2e6c",
+      "merkle_root": "sha256:1a79a4d60de6718e8e5b326e338ae533"
+    },
+    "vector_index": {
+      "locator": "pgvector://prod-db/schema.embeddings_v3",
+      "hash": "sha256:ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb",
+      "snapshot_ts": "2024-03-01T00:00:00+00:00"
+    },
+    "prompt_template": {
+      "name": "financial-compliance-assistant",
+      "version": "2.1.0",
+      "hash": "sha256:3fdba35f04dc8c462986c992bcf875546169049237a04d51de99e41f0bb4a5c6"
+    },
+    "grounding_citations": {
+      "citations": [
+        {
+          "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32024R1689",
+          "title": "EU AI Act — Official Journal of the European Union",
+          "retrieved_at": "2024-03-22T14:04:55+00:00",
+          "content_hash": "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+          "provider": "google-search"
+        },
+        {
+          "url": "https://www.eba.europa.eu/sites/default/files/2024-01/DORA_consolidated.pdf",
+          "title": "DORA Consolidated Text — EBA",
+          "retrieved_at": "2024-03-22T14:04:57+00:00",
+          "content_hash": "sha256:82e35a63ceba37e9646434c5dd412ea577147f1e4a41ccde1614253187e3dbbc",
+          "provider": "google-search"
+        }
+      ]
+    }
+  },
+  "manifest_signature": {
+    "algorithm": "ECDSA-P256-SHA256",
+    "signer": "openEAGO-demo-signer-v1",
+    "value": "MEYCIQDx7k3v...base64url-encoded-DER-signature...==",
+    "timestamp": "2024-03-22T14:05:01.456789+00:00"
+  }
+}
+```
+
+### Field reference
+
+| Field | Type | Description |
+|---|---|---|
+| `invocation_id` | string | Unique ID for this inference call |
+| `trace_root` | string | Root span ID from the distributed trace |
+| `created_at` | ISO-8601 | Manifest creation time (UTC) |
+| `sources.model_runtime.locator` | string | OCI image ref including digest |
+| `sources.model_runtime.sbom.hash` | `sha256:<hex>` | Hash of the CycloneDX/SPDX SBOM |
+| `sources.model_weights.commit` | string | Exact model version (git SHA or tag) |
+| `sources.model_weights.hash` | `sha256:<hex>` | Hash of weights artifact |
+| `sources.model_weights.signature` | object | Optional cosign/sigstore bundle ref |
+| `sources.rag.index_snapshot.hash` | `sha256:<hex>` | Hash of serialised vector index |
+| `sources.rag.chunks[].chunk_hash` | `sha256:<hex>` | Per-chunk content hash |
+| `sources.rag.chunks[].retrieval_score` | float | Similarity score at retrieval time |
+| `sources.training_data.merkle_root` | `sha256:<hex>` | Optional Merkle root over dataset shards |
+| `sources.vector_index.snapshot_ts` | ISO-8601 | When the index snapshot was taken |
+| `sources.prompt_template.hash` | `sha256:<hex>` | Hash of raw template text |
+| `sources.grounding_citations.citations[].url` | string | Canonical URL of the cited external source |
+| `sources.grounding_citations.citations[].retrieved_at` | ISO-8601 | When the URL was fetched |
+| `sources.grounding_citations.citations[].content_hash` | `sha256:<hex>` | Hash of fetched content at retrieval time |
+| `sources.grounding_citations.citations[].provider` | string | Search/grounding provider (e.g. `"google-search"`) |
+| `manifest_signature.value` | base64url | DER-encoded ECDSA signature (no padding) |
+
+All `sources.*` fields are **optional** — omit any that are not applicable.
+The `manifest_signature` field is excluded from the signed payload; everything
+else is covered.
+
+---
+
+## Design Decisions
+
+### 1. Pydantic v2 for schema enforcement
+
+All manifest fields are typed Pydantic `BaseModel` subclasses.  Optional
+fields mean partial manifests (e.g. no RAG source) are valid — the verifier
+notes only the sources that are present.  `model_dump(mode="json")` produces
+JSON-safe dicts without custom serializers.
+
+### 2. Canonical bytes for signing
+
+`ProvenanceManifest.canonical_bytes()` serialises the manifest to
+deterministic JSON (sorted keys, no whitespace) with `manifest_signature`
+excluded.  This matches the pattern used in `shared/prompt_hash.py` and
+ensures the signed payload is byte-for-byte reproducible regardless of
+field insertion order.
+
+### 3. ECDSA P-256 via `cryptography`
+
+The `cryptography` package (Apache-2.0) provides FIPS-aligned ECDSA P-256
+(secp256r1) without requiring blockchain toolchains or network access.
+DER-encoded signatures are stored as base64url strings (RFC 4648 §5, no
+padding) in `ManifestSignature.value`.
+
+In production the private key would live in a HSM / Vault Transit secret
+engine / AWS KMS, replacing only the `sign_manifest` internals — the manifest
+schema and verification logic remain unchanged.
+
+### 4. Structured VerificationResult
+
+`VerificationResult` separates passing `checks` from `failures` so audit
+tooling can surface granular evidence rather than a single boolean.  Each
+populated source field generates an independent check line, enabling partial
+trust decisions (e.g. signature valid but weights not re-fetched yet).
+
+### 5. rehash_artifact stubs
+
+`verifier.rehash_artifact` is intentionally a stub.  Real implementations
+would stream the artifact from its `locator`, compute SHA-256, and compare
+against the stored hash.  The stub pattern keeps the demo runnable without
+registry access while making the integration point explicit.
+
+---
+
+## Compliance Alignment
+
+| Requirement | How manifest addresses it |
+|---|---|
+| EU AI Act Art. 13 — Transparency | `invocation_id` + `trace_root` link manifest to LLM trace |
+| EU AI Act Art. 9 — Risk management | All model component hashes enable post-hoc audit |
+| DORA Art. 6 — ICT risk | Signed manifest provides tamper evidence for incident response |
+| SOC 2 CC6.1 — Logical access | `signer` field records which key/service produced the manifest |
+
+---
+
+## Extension Points
+
+- **Keyless signing**: replace `signer.py` with a Sigstore/Fulcio workflow for
+  certificate-backed, identity-rooted signatures without long-lived key material.
+- **On-chain anchoring**: hash the canonical bytes and store on a public ledger
+  for independent timestamp verification.
+- **Streaming RAG**: extend `RagSource` with a Merkle tree over all chunks so
+  individual chunks can be verified without the full index snapshot.
+- **MCP integration**: emit the manifest as a structured tool-call result in the
+  OpenEAGO MCP server so orchestrators can attach provenance to every response.

--- a/examples/provenance_manifest/demo.py
+++ b/examples/provenance_manifest/demo.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Demo: build, sign, and verify a Provenance Manifest end-to-end.
+
+Scenario: a financial-services AI agent performs an inference.  We capture
+every component (runtime, model weights, RAG index + chunks, prompt template)
+into a cryptographically signed ProvenanceManifest suitable for EU AI Act /
+DORA audit trails.
+
+Run:
+    cd examples/provenance_manifest
+    pip install -e .
+    python demo.py
+"""
+
+import json
+
+from provenance_manifest import (
+    ManifestSources,
+    build_manifest,
+    collect_grounding_citations,
+    collect_model_runtime,
+    collect_model_weights,
+    collect_prompt_template,
+    collect_rag_chunks,
+    generate_key_pair,
+    sign_manifest,
+    verify_manifest,
+)
+
+# ---------------------------------------------------------------------------
+# 1. Generate an ephemeral ECDSA P-256 key pair
+#    (in production: loaded from a HSM / Vault / KMS)
+# ---------------------------------------------------------------------------
+print("=" * 64)
+print("OpenEAGO Provenance Manifest — End-to-End Demo")
+print("=" * 64)
+
+print("\n[1] Generating ECDSA P-256 key pair ...")
+private_pem, public_pem = generate_key_pair()
+print("    Key pair generated (private key stays in memory, not persisted).")
+
+# ---------------------------------------------------------------------------
+# 2. Simulate collecting all source artifacts
+# ---------------------------------------------------------------------------
+print("\n[2] Collecting source artifacts ...")
+
+# Model runtime: OCI image with SBOM
+sbom_content = b'{"bomFormat":"CycloneDX","specVersion":"1.4","components":[]}'
+runtime_src = collect_model_runtime(
+    image_ref="ghcr.io/finos-labs/open-eago-agent@sha256:abc123def456",
+    sbom_data=sbom_content,
+)
+print(f"    runtime  : {runtime_src.locator}")
+print(f"    sbom hash: {runtime_src.sbom.hash}")
+
+# Model weights: HuggingFace repo
+weights_bytes = b"<simulated-model-weights-binary-blob>"
+weights_src = collect_model_weights(
+    locator="hf://finos-labs/open-eago-financial-7b",
+    commit="a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+    content_bytes=weights_bytes,
+)
+print(f"    weights  : {weights_src.locator} @ {weights_src.commit[:12]}...")
+print(f"    hash     : {weights_src.hash}")
+
+# RAG source: index snapshot + retrieved chunks
+rag_index_bytes = b"<serialised-faiss-index-snapshot>"
+rag_src = collect_rag_chunks(
+    chunks=[
+        {
+            "source_doc_id": "doc-regulatory-guidelines-2024",
+            "content": b"Article 13: Transparency obligations for high-risk AI systems...",
+            "retrieval_score": 0.92,
+        },
+        {
+            "source_doc_id": "doc-dora-technical-standards",
+            "content": b"Section 4.2: ICT risk management requirements for financial entities...",
+            "retrieval_score": 0.87,
+        },
+    ],
+    index_locator="s3://finos-labs-vectors/financial-compliance-v3/snapshot-2024-03-01",
+    index_bytes=rag_index_bytes,
+)
+print(f"    rag index: {rag_src.index_snapshot.locator}")
+print(f"    chunks   : {len(rag_src.chunks)} retrieved")
+
+# Prompt template
+prompt_content = (
+    "You are a compliance assistant for financial services.\n"
+    "Answer only based on the provided regulatory context.\n"
+    "Context: {{context}}\nQuestion: {{question}}"
+)
+prompt_src = collect_prompt_template(
+    name="financial-compliance-assistant",
+    version="2.1.0",
+    content=prompt_content,
+)
+print(f"    prompt   : {prompt_src.name} v{prompt_src.version}")
+print(f"    hash     : {prompt_src.hash}")
+
+# Grounding citations: external sources fetched at inference time
+citations_src = collect_grounding_citations(
+    citations=[
+        {
+            "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32024R1689",
+            "title": "EU AI Act — Official Journal of the European Union",
+            "retrieved_at": "2024-03-22T14:04:55+00:00",
+            "content": b"Regulation (EU) 2024/1689 of the European Parliament...",
+            "provider": "google-search",
+        },
+        {
+            "url": "https://www.eba.europa.eu/sites/default/files/2024-01/DORA_consolidated.pdf",
+            "title": "DORA Consolidated Text — EBA",
+            "retrieved_at": "2024-03-22T14:04:57+00:00",
+            "content": b"Digital Operational Resilience Act (DORA) consolidated...",
+            "provider": "google-search",
+        },
+    ]
+)
+print(f"    citations: {len(citations_src.citations)} grounding source(s) recorded")
+for c in citations_src.citations:
+    print(f"      [{c.provider}] {c.url}")
+    print(f"       hash: {c.content_hash}")
+
+# ---------------------------------------------------------------------------
+# 3. Build the ProvenanceManifest
+# ---------------------------------------------------------------------------
+print("\n[3] Building ProvenanceManifest ...")
+sources = ManifestSources(
+    model_runtime=runtime_src,
+    model_weights=weights_src,
+    rag=rag_src,
+    prompt_template=prompt_src,
+    grounding_citations=citations_src,
+)
+manifest = build_manifest(
+    invocation_id="inv-2024-03-22-financial-7b-001",
+    trace_root="trace-root-sha256-fedcba9876543210",
+    sources=sources,
+)
+print(f"    invocation_id : {manifest.invocation_id}")
+print(f"    trace_root    : {manifest.trace_root}")
+print(f"    created_at    : {manifest.created_at}")
+
+# ---------------------------------------------------------------------------
+# 4. Sign the manifest
+# ---------------------------------------------------------------------------
+print("\n[4] Signing manifest (ECDSA P-256 / SHA-256) ...")
+signed = sign_manifest(
+    manifest=manifest,
+    private_key_pem=private_pem,
+    signer_id="openEAGO-demo-signer-v1",
+)
+sig = signed.manifest_signature
+print(f"    algorithm : {sig.algorithm}")
+print(f"    signer    : {sig.signer}")
+print(f"    timestamp : {sig.timestamp}")
+print(f"    value     : {sig.value[:40]}...")
+
+# ---------------------------------------------------------------------------
+# 5. Print full manifest JSON
+# ---------------------------------------------------------------------------
+print("\n[5] Full signed manifest (JSON):")
+print("-" * 64)
+print(json.dumps(signed.to_dict(), indent=2))
+print("-" * 64)
+
+# ---------------------------------------------------------------------------
+# 6. Verify — all checks should pass
+# ---------------------------------------------------------------------------
+print("\n[6] Verifying manifest ...")
+result = verify_manifest(signed, public_pem)
+print(f"    valid  : {result.valid}")
+print(f"    checks : {len(result.checks)}")
+for c in result.checks:
+    print(f"      [PASS] {c}")
+if result.failures:
+    for f in result.failures:
+        print(f"      [FAIL] {f}")
+
+assert result.valid, f"Verification failed unexpectedly: {result.failures}"
+print("    All checks passed.")
+
+# ---------------------------------------------------------------------------
+# 7. Tamper test — mutate trace_root, verify should fail
+# ---------------------------------------------------------------------------
+print("\n[7] Tamper test: mutating trace_root ...")
+tampered = signed.model_copy(update={"trace_root": "TAMPERED-trace-root-000000"})
+tamper_result = verify_manifest(tampered, public_pem)
+print(f"    valid  : {tamper_result.valid}")
+for f in tamper_result.failures:
+    print(f"    [FAIL] {f}")
+
+assert not tamper_result.valid, "Tamper test should have failed verification!"
+print("    Tamper detected correctly.")
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+print("\n" + "=" * 64)
+print("All assertions passed.")
+print(f"  Invocation : {signed.invocation_id}")
+print(f"  Algorithm  : {sig.algorithm}")
+print(f"  Signer     : {sig.signer}")
+print(f"  Sources    : runtime, weights, rag ({len(rag_src.chunks)} chunks), prompt, {len(citations_src.citations)} citations")
+print(f"  Canonical  : {len(signed.canonical_bytes())} bytes signed")
+print(f"  Sig length : {len(sig.value)} chars (base64url)")
+print(f"  Tamper     : detected via signature mismatch")
+print("=" * 64)

--- a/examples/provenance_manifest/proposal.md
+++ b/examples/provenance_manifest/proposal.md
@@ -1,0 +1,111 @@
+**Detailed summary of the conversation thread**  
+This thread is an engineering research discussion focused on enhancing **OpenEAGO** (Open Enterprise Agent Governance and Orchestration Protocol — https://github.com/finos-labs/open-eago) with strong **evidentiary / forensic / audit-grade provenance** for AI agent invocations. The core goal is to make the entire chain **addressable, versioned, and immutable** from an evidence perspective — so that every decision or output can be later proven with cryptographic certainty (e.g., for regulatory audits, compliance, reproducibility, or liability questions in enterprise settings).
+
+The discussion evolves step-by-step around what needs to be captured in a **provenance manifest** (a signed, structured record attached to OpenEAGO traces), building on the existing tracing extension (referenced as section 4.4 in "the paper" — likely an internal or draft research document not public on the repo as of March 2026).
+
+### 1. Initial question: What's missing in the full invocation chain for evidence purposes?
+
+**Original chain listed by user:**
+- Caller
+- MCP server (Multi-Agent Control Plane / orchestration layer)
+- Agent code
+- Model runtime
+- Model training data
+- Model vector data
+- Model weights
+- RAG
+
+**Key insight:**  
+Code (MCP server + agent code) is already well-covered via Git commit SHAs + CI/CD provenance (e.g. SLSA attestations).  
+Everything below the code layer (runtime, weights, data, vectors, RAG) is typically **not** immutable or verifiable today — floating tags ("latest"), mutable repos, no frozen snapshots.
+
+**Missing evidentiary pieces highlighted:**
+- Governance/compliance validation layer
+- Agent registry / negotiation
+- Resilience & execution controls
+- Context/state management
+- Secure communication
+- But reframed strictly for **bundling evidence**: runtime image digests, model weights hashes, dataset Merkle roots, vector index snapshots, retrieved RAG chunks hashes, prompt templates, etc.
+
+**Proposed solution:** A **Provenance Manifest** (signed JSON/CBOR) attached to every trace that collects hashes/digests/locators for the full chain.
+
+### 2. Follow-up: Should we add "sources" (locators + digests) directly into the manifest?
+
+**Consensus:** Yes — strongly recommended (though optional in early spec versions).  
+**Rationale:**
+- Captures everything at invocation time (when resolution is possible).
+- Enables offline cryptographic verification (fetch → re-hash → compare).
+- Aligns with OpenEAGO's **audit anchoring** in the Communication & Delivery layer.
+- Supports deterministic replay and regulatory needs (EU AI Act, DORA, etc.).
+
+**Proposed structure snippet (sample JSON fragment):**
+
+```json
+{
+  "invocation_id": "trace-uuid-1234",
+  "trace_root": "openeago-trace-v4.4-root-hash",
+  "sources": {
+    "model_runtime": {
+      "locator": "docker.io/vllm-project/vllm-openai@sha256:abcdef1234567890...",
+      "sbom": {
+        "format": "cyclonedx",
+        "hash": "sha256:..."
+      }
+    },
+    "model_weights": {
+      "locator": "https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct/tree/abcdef1234",
+      "commit": "abcdef1234567890",
+      "hash": "sha256:full-model-checkpoint-hash",
+      "signature": {
+        "type": "cosign",
+        "bundle_url": "https://rekor.sigstore.dev/..."
+      }
+    },
+    "rag_retrieved_chunks": {
+      "index_snapshot": {
+        "locator": "s3://company-rag-indexes/prod-v20260322-abc123",
+        "hash": "sha256:index-file-hash"
+      },
+      "chunks": [
+        {
+          "source_doc_id": "doc-uuid-5678",
+          "chunk_hash": "sha256:exact-chunk-content-hash",
+          "retrieval_score": 0.92
+        }
+      ]
+    }
+    // ... training_data, vector_data, prompt_templates, etc.
+  },
+  "manifest_signature": {
+    "algorithm": "ecdsa-secp256k1",
+    "signer": "mcp-server-key-2026",
+    "value": "...",
+    "timestamp": "2026-03-22T14:30:00Z"
+  }
+}
+```
+
+### 3. Final point: Should sources be optional or mandatory?
+
+**Decision:** **Optional** (pragmatic for early adoption in v0.1.x era).  
+**But strongly recommended** — especially for regulated enterprises.
+
+**Likelihood enterprises will populate them:**
+
+| Artifact              | Enterprise Want/Need Level | Reason |
+|-----------------------|-----------------------------|--------|
+| Model weights hash + locator | Extremely high             | Core attack surface; already in many policies |
+| Model runtime digest | Very high                  | SBOMs are becoming standard |
+| RAG retrieved chunks hashes | High                       | Explainability / hallucination defense |
+| Vector index snapshot | High                       | Drift detection |
+| Training data Merkle root | Medium–high (rising)       | Hardest; EU AI Act pressure |
+
+**Recommended spec guidance phrasing:**
+- `sources` is optional to reduce barriers.
+- Enterprises **SHOULD** populate at minimum: model_weights (locator + hash), model_runtime (digest), rag chunks/index hashes.
+- When provided, manifest **SHOULD** be signed and anchored via OpenEAGO audit mechanism.
+
+**Overall thread direction:**  
+The conversation is driving OpenEAGO toward becoming a protocol that doesn't just orchestrate agents compliantly, but also produces **self-verifying, cryptographically provable inference records** — turning tracing (section 4.4) into full evidentiary bundles. This positions the project well for 2026–2027 regulated deployments in finance and other high-stakes domains.
+
+Next likely research steps (implied): prototype the optional `sources` collection in the MCP server, test replay with sample traces, and gather feedback on which fields are easiest to populate in real pilots.

--- a/examples/provenance_manifest/provenance_manifest/__init__.py
+++ b/examples/provenance_manifest/provenance_manifest/__init__.py
@@ -1,0 +1,65 @@
+"""OpenEAGO Provenance Manifest — public API."""
+
+from .collector import (
+    build_manifest,
+    collect_grounding_citations,
+    collect_model_runtime,
+    collect_model_weights,
+    collect_prompt_template,
+    collect_rag_chunks,
+    hash_content,
+)
+from .models import (
+    DatasetSource,
+    GroundingCitation,
+    GroundingCitationsSource,
+    ManifestSignature,
+    ManifestSources,
+    ModelRuntimeSource,
+    ModelWeightsSource,
+    PromptTemplateSource,
+    ProvenanceManifest,
+    RagChunk,
+    RagIndexSnapshot,
+    RagSource,
+    SBOMRef,
+    SignatureRef,
+    VectorIndexSource,
+)
+from .signer import generate_key_pair, sign_manifest, verify_signature
+from .verifier import VerificationResult, rehash_artifact, verify_manifest
+
+__all__ = [
+    # models
+    "GroundingCitation",
+    "GroundingCitationsSource",
+    "SBOMRef",
+    "SignatureRef",
+    "ModelRuntimeSource",
+    "ModelWeightsSource",
+    "RagChunk",
+    "RagIndexSnapshot",
+    "RagSource",
+    "DatasetSource",
+    "VectorIndexSource",
+    "PromptTemplateSource",
+    "ManifestSources",
+    "ManifestSignature",
+    "ProvenanceManifest",
+    # collector
+    "hash_content",
+    "collect_model_runtime",
+    "collect_model_weights",
+    "collect_rag_chunks",
+    "collect_prompt_template",
+    "collect_grounding_citations",
+    "build_manifest",
+    # signer
+    "generate_key_pair",
+    "sign_manifest",
+    "verify_signature",
+    # verifier
+    "VerificationResult",
+    "rehash_artifact",
+    "verify_manifest",
+]

--- a/examples/provenance_manifest/provenance_manifest/collector.py
+++ b/examples/provenance_manifest/provenance_manifest/collector.py
@@ -1,0 +1,129 @@
+"""Artifact collection helpers for building ProvenanceManifest source fields.
+
+In production these functions would call real registries, content-addressable
+stores, and index snapshotting APIs.  Here they accept pre-known bytes/digests
+and compute hashes locally, making the module usable without external I/O.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+from typing import Any
+
+from .models import (
+    GroundingCitation,
+    GroundingCitationsSource,
+    ManifestSources,
+    ModelRuntimeSource,
+    ModelWeightsSource,
+    PromptTemplateSource,
+    ProvenanceManifest,
+    RagChunk,
+    RagIndexSnapshot,
+    RagSource,
+    SBOMRef,
+)
+
+
+def hash_content(data: bytes) -> str:
+    """Return 'sha256:<hex>' digest of *data*."""
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def collect_model_runtime(
+    image_ref: str,
+    sbom_data: bytes | None = None,
+) -> ModelRuntimeSource:
+    sbom = None
+    if sbom_data is not None:
+        sbom = SBOMRef(format="cyclonedx-json", hash=hash_content(sbom_data))
+    return ModelRuntimeSource(locator=image_ref, sbom=sbom)
+
+
+def collect_model_weights(
+    locator: str,
+    commit: str,
+    content_bytes: bytes,
+) -> ModelWeightsSource:
+    return ModelWeightsSource(
+        locator=locator,
+        commit=commit,
+        hash=hash_content(content_bytes),
+    )
+
+
+def collect_rag_chunks(
+    chunks: list[dict[str, Any]],
+    index_locator: str,
+    index_bytes: bytes,
+) -> RagSource:
+    """Build a RagSource from a list of chunk dicts.
+
+    Each dict must contain: source_doc_id (str), content (bytes|str),
+    retrieval_score (float).
+    """
+    rag_chunks = []
+    for c in chunks:
+        content = c["content"]
+        if isinstance(content, str):
+            content = content.encode()
+        rag_chunks.append(
+            RagChunk(
+                source_doc_id=c["source_doc_id"],
+                chunk_hash=hash_content(content),
+                retrieval_score=float(c["retrieval_score"]),
+            )
+        )
+    return RagSource(
+        index_snapshot=RagIndexSnapshot(
+            locator=index_locator,
+            hash=hash_content(index_bytes),
+        ),
+        chunks=rag_chunks,
+    )
+
+
+def collect_grounding_citations(
+    citations: list[dict[str, Any]],
+) -> GroundingCitationsSource:
+    """Build a GroundingCitationsSource from a list of citation dicts.
+
+    Each dict must contain: url (str), content (bytes|str), retrieved_at (str).
+    Optional keys: title (str), provider (str).
+    """
+    result = []
+    for c in citations:
+        content = c["content"]
+        if isinstance(content, str):
+            content = content.encode()
+        result.append(
+            GroundingCitation(
+                url=c["url"],
+                title=c.get("title"),
+                retrieved_at=c["retrieved_at"],
+                content_hash=hash_content(content),
+                provider=c.get("provider"),
+            )
+        )
+    return GroundingCitationsSource(citations=result)
+
+
+def collect_prompt_template(name: str, version: str, content: str) -> PromptTemplateSource:
+    return PromptTemplateSource(
+        name=name,
+        version=version,
+        hash=hash_content(content.encode()),
+    )
+
+
+def build_manifest(
+    invocation_id: str,
+    trace_root: str,
+    sources: ManifestSources,
+) -> ProvenanceManifest:
+    return ProvenanceManifest(
+        invocation_id=invocation_id,
+        trace_root=trace_root,
+        sources=sources,
+    )

--- a/examples/provenance_manifest/provenance_manifest/models.py
+++ b/examples/provenance_manifest/provenance_manifest/models.py
@@ -1,0 +1,121 @@
+"""Pydantic v2 models for OpenEAGO Provenance Manifest.
+
+Mirrors the JSON structure from the provenance manifest proposal (section 4.4).
+All source fields are Optional so partial manifests are valid.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
+
+class SBOMRef(BaseModel):
+    format: str  # e.g. "cyclonedx-json", "spdx-json"
+    hash: str    # sha256:<hex>
+
+
+class SignatureRef(BaseModel):
+    type: str         # e.g. "cosign", "sigstore"
+    bundle_url: str   # URL to the signature bundle
+
+
+class ModelRuntimeSource(BaseModel):
+    locator: str           # OCI image ref, e.g. "ghcr.io/org/agent:sha256-..."
+    sbom: Optional[SBOMRef] = None
+
+
+class ModelWeightsSource(BaseModel):
+    locator: str           # HuggingFace repo or S3 URI
+    commit: str            # git commit SHA or model version tag
+    hash: str              # sha256:<hex> of weights artifact
+    signature: Optional[SignatureRef] = None
+
+
+class RagChunk(BaseModel):
+    source_doc_id: str
+    chunk_hash: str        # sha256:<hex>
+    retrieval_score: float
+
+
+class RagIndexSnapshot(BaseModel):
+    locator: str           # S3 URI, ANN index path
+    hash: str              # sha256:<hex> of serialised index
+
+
+class RagSource(BaseModel):
+    index_snapshot: RagIndexSnapshot
+    chunks: list[RagChunk] = Field(default_factory=list)
+
+
+class DatasetSource(BaseModel):
+    locator: str           # Dataset registry URI
+    hash: str              # sha256:<hex> of canonical archive
+    merkle_root: Optional[str] = None  # Merkle root if dataset is chunked
+
+
+class VectorIndexSource(BaseModel):
+    locator: str           # Vector DB URI / snapshot path
+    hash: str              # sha256:<hex>
+    snapshot_ts: str       # ISO-8601 timestamp of snapshot
+
+
+class PromptTemplateSource(BaseModel):
+    name: str
+    version: str
+    hash: str              # sha256:<hex> of template content
+
+
+class GroundingCitation(BaseModel):
+    url: str               # Canonical URL of the cited source
+    title: Optional[str] = None
+    retrieved_at: str      # ISO-8601 timestamp of fetch
+    content_hash: str      # sha256:<hex> of the fetched content at retrieval time
+    provider: Optional[str] = None  # e.g. "google-search", "bing", "perplexity"
+
+
+class GroundingCitationsSource(BaseModel):
+    citations: list[GroundingCitation] = Field(default_factory=list)
+
+
+class ManifestSources(BaseModel):
+    model_runtime: Optional[ModelRuntimeSource] = None
+    model_weights: Optional[ModelWeightsSource] = None
+    rag: Optional[RagSource] = None
+    training_data: Optional[DatasetSource] = None
+    vector_index: Optional[VectorIndexSource] = None
+    prompt_template: Optional[PromptTemplateSource] = None
+    grounding_citations: Optional[GroundingCitationsSource] = None
+
+
+class ManifestSignature(BaseModel):
+    algorithm: str   # e.g. "ECDSA-P256-SHA256"
+    signer: str      # identifier of the signing key / service
+    value: str       # base64url-encoded DER signature (excluded from signed payload)
+    timestamp: str   # ISO-8601 signing time
+
+
+class ProvenanceManifest(BaseModel):
+    invocation_id: str
+    trace_root: str
+    created_at: str = Field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+    sources: ManifestSources = Field(default_factory=ManifestSources)
+    manifest_signature: Optional[ManifestSignature] = None
+
+    def canonical_bytes(self) -> bytes:
+        """Deterministic JSON (sorted keys, no whitespace) for signing.
+
+        The manifest_signature field is excluded so that the signed payload
+        does not depend on the signature value itself.
+        """
+        d = self.to_dict()
+        d.pop("manifest_signature", None)
+        return json.dumps(d, sort_keys=True, separators=(",", ":")).encode()
+
+    def to_dict(self) -> dict[str, Any]:
+        return self.model_dump(mode="json")

--- a/examples/provenance_manifest/provenance_manifest/signer.py
+++ b/examples/provenance_manifest/provenance_manifest/signer.py
@@ -1,0 +1,95 @@
+"""ECDSA P-256 sign and verify for ProvenanceManifest.
+
+Uses the `cryptography` package (no blockchain or external service deps).
+Signatures are DER-encoded and stored as base64url strings in
+ManifestSignature.value.
+"""
+
+from __future__ import annotations
+
+import base64
+from datetime import datetime, timezone
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from .models import ManifestSignature, ProvenanceManifest
+
+ALGORITHM = "ECDSA-P256-SHA256"
+
+
+def generate_key_pair() -> tuple[str, str]:
+    """Generate an ECDSA P-256 key pair.
+
+    Returns:
+        (private_key_pem, public_key_pem) as UTF-8 strings.
+    """
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    public_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return private_pem, public_pem
+
+
+def sign_manifest(
+    manifest: ProvenanceManifest,
+    private_key_pem: str,
+    signer_id: str,
+) -> ProvenanceManifest:
+    """Sign *manifest* and return a new manifest with manifest_signature set.
+
+    The canonical payload (manifest without manifest_signature) is hashed
+    with SHA-256 and signed with ECDSA P-256.  The DER-encoded signature is
+    stored base64url-encoded (no padding) in ManifestSignature.value.
+    """
+    payload = manifest.canonical_bytes()
+
+    private_key = serialization.load_pem_private_key(
+        private_key_pem.encode(), password=None
+    )
+    # cryptography signs with SHA-256 internally via ECDSA
+    der_sig = private_key.sign(payload, ec.ECDSA(hashes.SHA256()))
+    sig_b64 = base64.urlsafe_b64encode(der_sig).rstrip(b"=").decode()
+
+    signed = manifest.model_copy(
+        update={
+            "manifest_signature": ManifestSignature(
+                algorithm=ALGORITHM,
+                signer=signer_id,
+                value=sig_b64,
+                timestamp=datetime.now(timezone.utc).isoformat(),
+            )
+        }
+    )
+    return signed
+
+
+def verify_signature(manifest: ProvenanceManifest, public_key_pem: str) -> bool:
+    """Return True if manifest_signature is a valid ECDSA P-256 signature.
+
+    Raises ValueError if manifest has no signature.
+    """
+    if manifest.manifest_signature is None:
+        raise ValueError("Manifest has no signature to verify.")
+
+    payload = manifest.canonical_bytes()
+    sig_value = manifest.manifest_signature.value
+
+    # Restore base64url padding
+    padding = 4 - len(sig_value) % 4
+    if padding != 4:
+        sig_value += "=" * padding
+    der_sig = base64.urlsafe_b64decode(sig_value)
+
+    public_key = serialization.load_pem_public_key(public_key_pem.encode())
+    try:
+        public_key.verify(der_sig, payload, ec.ECDSA(hashes.SHA256()))
+        return True
+    except Exception:
+        return False

--- a/examples/provenance_manifest/provenance_manifest/verifier.py
+++ b/examples/provenance_manifest/provenance_manifest/verifier.py
@@ -1,0 +1,120 @@
+"""Full manifest verification and artifact re-hash stubs.
+
+VerificationResult accumulates per-check outcomes so callers can surface
+structured audit evidence rather than a single boolean.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+from .models import ProvenanceManifest
+from .signer import verify_signature
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class VerificationResult:
+    valid: bool
+    checks: list[str] = field(default_factory=list)
+    failures: list[str] = field(default_factory=list)
+
+
+def rehash_artifact(locator: str, expected_hash: str) -> bool:
+    """Stub: log the would-be verification and return True.
+
+    In production this would fetch *locator* from the registry, compute its
+    SHA-256, and compare against *expected_hash*.
+    """
+    logger.info("rehash_artifact: would verify %s == %s", locator, expected_hash)
+    return True
+
+
+def verify_manifest(
+    manifest: ProvenanceManifest,
+    public_key_pem: str,
+) -> VerificationResult:
+    """Run all verification checks and return a structured result."""
+    checks: list[str] = []
+    failures: list[str] = []
+
+    # --- Required fields ---
+    if manifest.invocation_id:
+        checks.append("invocation_id present")
+    else:
+        failures.append("invocation_id missing")
+
+    if manifest.trace_root:
+        checks.append("trace_root present")
+    else:
+        failures.append("trace_root missing")
+
+    # --- Cryptographic signature ---
+    if manifest.manifest_signature is None:
+        failures.append("manifest_signature absent")
+    else:
+        try:
+            ok = verify_signature(manifest, public_key_pem)
+        except Exception as exc:
+            ok = False
+            failures.append(f"signature verification error: {exc}")
+
+        if ok:
+            checks.append(f"signature valid ({manifest.manifest_signature.algorithm})")
+        else:
+            failures.append("signature INVALID — manifest may have been tampered with")
+
+    # --- Source artifact stubs ---
+    sources = manifest.sources
+    if sources.model_runtime is not None:
+        if rehash_artifact(sources.model_runtime.locator, ""):
+            checks.append(f"model_runtime verifiable: {sources.model_runtime.locator}")
+
+    if sources.model_weights is not None:
+        if rehash_artifact(sources.model_weights.locator, sources.model_weights.hash):
+            checks.append(
+                f"model_weights verifiable: {sources.model_weights.locator} "
+                f"@ {sources.model_weights.commit}"
+            )
+
+    if sources.rag is not None:
+        if rehash_artifact(
+            sources.rag.index_snapshot.locator,
+            sources.rag.index_snapshot.hash,
+        ):
+            checks.append(
+                f"rag_index verifiable: {sources.rag.index_snapshot.locator} "
+                f"({len(sources.rag.chunks)} chunks)"
+            )
+
+    if sources.training_data is not None:
+        if rehash_artifact(sources.training_data.locator, sources.training_data.hash):
+            checks.append(f"training_data verifiable: {sources.training_data.locator}")
+
+    if sources.vector_index is not None:
+        if rehash_artifact(sources.vector_index.locator, sources.vector_index.hash):
+            checks.append(
+                f"vector_index verifiable: {sources.vector_index.locator} "
+                f"snapshot={sources.vector_index.snapshot_ts}"
+            )
+
+    if sources.prompt_template is not None:
+        if rehash_artifact("prompt-registry", sources.prompt_template.hash):
+            checks.append(
+                f"prompt_template verifiable: {sources.prompt_template.name} "
+                f"v{sources.prompt_template.version}"
+            )
+
+    if sources.grounding_citations is not None:
+        n = len(sources.grounding_citations.citations)
+        for citation in sources.grounding_citations.citations:
+            rehash_artifact(citation.url, citation.content_hash)
+        checks.append(f"grounding_citations recorded: {n} citation(s)")
+
+    return VerificationResult(
+        valid=len(failures) == 0,
+        checks=checks,
+        failures=failures,
+    )

--- a/examples/provenance_manifest/pyproject.toml
+++ b/examples/provenance_manifest/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "openEAGO-provenance-manifest"
+version = "0.1.0"
+description = "Provenance Manifest example for OpenEAGO — signed, audit-grade inference records for regulated deployments"
+requires-python = ">=3.11"
+dependencies = [
+    "pydantic>=2.0",
+    "cryptography>=42.0",
+]
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["provenance_manifest*"]


### PR DESCRIPTION
Implements a standalone Python module (examples/provenance_manifest/) that builds, signs, and verifies a cryptographic ProvenanceManifest covering the full AI agent invocation chain — model runtime, weights, RAG index + chunks, training data, vector index, prompt template, and grounding citations.

---
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file.
- [x] My commit messages are signed off with the `Signed-off-by` statement (use `--signoff` in the commit).

By submitting this pull request, I certify that I have read and agree to the terms of the [Developer Certificate of Origin](https://developercertificate.org/).
